### PR TITLE
Add example script for custom timestamp labels

### DIFF
--- a/scripts/figure_labels_time_formatting.js
+++ b/scripts/figure_labels_time_formatting.js
@@ -1,0 +1,15 @@
+
+// Add time labels to 3 decimal places like "1.234 s"
+
+figureModel.getSelected().forEach(p => {
+    let theT = p.get('theT');
+    let deltaT = p.get('deltaT')?.[theT];
+    console.log("deltaT", deltaT);
+    if (deltaT == undefined) return;
+    p.add_labels([{
+        text: deltaT.toFixed(3) + " s",
+        size: 14,
+        position: 'topleft',
+        color: 'ffffff'
+    }]);
+});


### PR DESCRIPTION
Add a script for custom formatting of timestamp labels, as requested during OME2021 workshop.

To test:
 - Select some image panels in figure, with good timestamp data e.g. FRAP images
 - Run the script on selected images
 - Should see timestamp labels to 3 decimal places 

![Screenshot 2021-06-09 at 15 38 13](https://user-images.githubusercontent.com/900055/121375612-c5464380-c938-11eb-9aaf-35e0e24895d8.png)
like `1.234 s`