### PR TITLE
Table data by roi

### DIFF
--- a/docs/omero_figure_scripting.rst
+++ b/docs/omero_figure_scripting.rst
@@ -147,19 +147,19 @@ a heatmap of colors applied to Shapes on the figure panel.
 
 #.  Alternatively, perform the following steps:
 
-#.  For the Image you wish to use, add some ROIs to the Image. You can see the ROI and Shape IDs in the iviewer ROI table.
+#.  For the Image you wish to use, add some ROIs to the Image. You can see the ROI IDs in the iviewer ROI table.
 
-#.  To setup the OMERO.table, create a CSV file with an ``Roi`` column and a ``Shape`` column containing the corresponding IDs and 1
+#.  To setup the OMERO.table, create a CSV file with an ``Roi`` column containing the corresponding IDs and 1
     or more number columns. The ``#header`` defines the column types: ``l`` (long) for `integers` and ``d`` (double) for `floats`.
     For example:
 
     ::
 
         # header roi,l,d,d,l
-        Roi,Shape,Area,Sphericity,Pixels
-        1,10,34.5,0.5,110
-        2,11,18.2,0.6,55
-        2,12,44.1,0.9,210
+        Roi,Area,Sphericity,Pixels
+        1,34.5,0.5,110
+        2,18.2,0.6,55
+        2,44.1,0.9,210
 
 #.  Save the edited csv as ``data.csv``.
 
@@ -176,9 +176,9 @@ a heatmap of colors applied to Shapes on the figure panel.
     OMERO.
 
 #.  View the JavaScript snippet at `figure_table_data_shapes.js <https://github.com/ome/omero-guide-figure/tree/master/scripts/figure_table_data_shapes.js>`_.
-    This uses the ID of each Shape of the panel to query the most recent OMERO.table on the Image using the
-    endpoint: ``/webgateway/table/Image/{imageId}/query/?query=Shape-{shapeId}``, which returns
-    all table rows for that Shape ID. From the JSON returned, we find the column index for the
+    This uses the ID of each Shape of the panel to get the ROI ID and then query the most recent OMERO.table on the Image using the
+    endpoint: ``/webgateway/table/Image/{imageId}/query/?query=Roi-{roiId}``, which returns
+    all table rows for that Roi ID. From the JSON returned, we find the column index for the
     data we want, e.g. ``Sphericity``, and then get the value for that column.
     Once the values for all Shapes on the panel are loaded, the code calculates the range and
     generates a heatmap color for each value in that range. This is set as the color

--- a/docs/omero_figure_scripting.rst
+++ b/docs/omero_figure_scripting.rst
@@ -159,7 +159,7 @@ a heatmap of colors applied to Shapes on the figure panel.
         Roi,Area,Sphericity,Pixels
         1,34.5,0.5,110
         2,18.2,0.6,55
-        2,44.1,0.9,210
+        3,44.1,0.9,210
 
 #.  Save the edited csv as ``data.csv``.
 

--- a/docs/omero_figure_scripting.rst
+++ b/docs/omero_figure_scripting.rst
@@ -155,7 +155,7 @@ a heatmap of colors applied to Shapes on the figure panel.
 
     ::
 
-        # header roi,l,d,d,l
+        # header roi,d,d,l
         Roi,Area,Sphericity,Pixels
         1,34.5,0.5,110
         2,18.2,0.6,55

--- a/scripts/figure_table_data_shapes.js
+++ b/scripts/figure_table_data_shapes.js
@@ -32,14 +32,18 @@ async function shapeData(panel) {
     let vals_by_shape = {};
     for (let i = 0; i < shapeIds.length; i++) {
         // Load one at a time - more reliable
+        let shape_id = shapeIds[i];
         let base_url = window.location.href.split("figure")[0];
-        let url = base_url + `webgateway/table/Image/${panel.get('imageId')}/query/?query=Shape-${shapeIds[i]}`;
+        let shape_url = base_url + `api/v0/m/shapes/${shape_id}/`;
+        let shape = await fetch(shape_url).then(rsp => rsp.json());
+        let roi_id = parseInt(shape.data['url:roi'].split("rois/")[1]);
+        console.log("Shape ID", shape_id, "ROI ID", roi_id);
+        let url = base_url + `webgateway/table/Image/${panel.get('imageId')}/query/?query=Roi-${roi_id}`;
         let r = await fetch(url).then(rsp => rsp.json());
         let colIndex = r.data?.columns?.indexOf("Sphericity");
-        let shapeIndex = r.data?.columns?.indexOf("Shape");
-        if (colIndex && shapeIndex && r.data?.rows.length > 0) {
+        if (colIndex && r.data?.rows.length > 0) {
             console.log("Value", r.data.rows[0][colIndex]);
-            vals_by_shape[r.data.rows[0][shapeIndex]] = r.data.rows[0][colIndex];
+            vals_by_shape[shape_id] = r.data.rows[0][colIndex];
         }
     };
     // Once all loaded, we can calculate range and assign colours to shapes


### PR DESCRIPTION
Now that https://github.com/ome/omero-web/pull/291 is merged, we can get the ROI ID from Shape ID.

This means we don't need to add an OMERO.table row for every Shape, so we can use the same OMERO.tables as
are in IDR instead of creating custom tables for this workflow.

This PR updates the script to get ROI ID from Shape ID, then to query the OMERO.table by ROI ID.

To test:
 - Follow setup steps in https://github.com/ome/training-scripts/pull/88
 - Follow the "Shapes heatmap from OMERO.table" section of `omero_figure_scripting.rst`

TODO: update https://github.com/will-moore/training-scripts/blob/ome_2021_workshop_features/maintenance/preparation/idr0079-data-prep.md once https://github.com/ome/training-scripts/pull/88 is merged.